### PR TITLE
Add laravel seo

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,8 +1,15 @@
+
+
 <!doctype html>
 <html lang="{{ app()->getLocale() }}">
 <head>
     @if (class_exists(RalphJSmit\Laravel\SEO\SEOManager::class))
-        {!! seo() !!}
+        @isset($page)
+            {!! seo()->for($page) !!}
+        @endisset
+        @isset($post)
+            {!! seo()->for($post) !!}
+        @endisset
     @endif
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,41 +1,42 @@
 <!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="{{ app()->getLocale() }}">
+<head>
+    @if (class_exists(RalphJSmit\Laravel\SEO\SEOManager::class))
+        {!! seo() !!}
+    @endif
 
-        @if (View::exists('googletagmanager::head') && config('layouts-wrapper.gtm_enabled'))
-            @include('googletagmanager::head')
-        @endif
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @if (class_exists(\Livewire\Livewire::class) && config('layouts-wrapper.livewire_enabled'))
+        @livewireStyles
+    @endif
 
-        @if (class_exists(\Livewire\Livewire::class) && config('layouts-wrapper.livewire_enabled'))
-            @livewireStyles
-        @endif
+    @if(class_exists(\Spatie\GoogleFonts\GoogleFonts::class))
+        @googlefonts
+    @endif
 
-        @if(class_exists(\Spatie\GoogleFonts\GoogleFonts::class))
-            @googlefonts
-        @endif
-    </head>
-    <body>
-        @if (View::exists('navigation::components.navigation') && config('layouts-wrapper.navigation_enabled'))
-            <x-navigation::navigation />
-        @endif
+    @if (View::exists('googletagmanager::head') && config('layouts-wrapper.gtm_enabled'))
+        @include('googletagmanager::head')
+    @endif
+</head>
+<body>
+    @if (View::exists('navigation::components.navigation') && config('layouts-wrapper.navigation_enabled'))
+        <x-navigation::navigation />
+    @endif
 
-        {{ $slot }}
+    {{ $slot }}
 
-        @if (View::exists('forms::livewire.forms-modal') && config('layouts-wrapper.forms_modal_enabled'))
-            @livewire('forms-modal')
-        @endif
+    @if (View::exists('forms::livewire.forms-modal') && config('layouts-wrapper.forms_modal_enabled'))
+        @livewire('forms-modal')
+    @endif
 
-        @if (View::exists('googletagmanager::body') && config('layouts-wrapper.gtm_enabled'))
-            @include('googletagmanager::body')
-        @endif
+    @if (View::exists('googletagmanager::body') && config('layouts-wrapper.gtm_enabled'))
+        @include('googletagmanager::body')
+    @endif
 
-        @if (class_exists(\Livewire\Livewire::class) && config('layouts-wrapper.livewire_enabled'))
-            @livewireScripts
-        @endif
-    </body>
+    @if (class_exists(\Livewire\Livewire::class) && config('layouts-wrapper.livewire_enabled'))
+        @livewireScripts
+    @endif
+</body>
 </html>
 


### PR DESCRIPTION
Introduces the addition of Laravel SEO functionality to our project. By incorporating Laravel SEO into the app layout, we can now dynamically generate SEO meta tags for individual pages and posts.

The changes in the `app.blade.php` file enable the usage of Laravel SEO to generate SEO meta tags based on the specific page or post being rendered. This enhancement allows us to optimize the SEO performance of our website by customizing meta tags for each page or post.

Implementing Laravel SEO in our project will improve our website's search engine visibility and enhance the overall SEO strategy.