### PR TITLE
Update auto-release.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event.action == 'merged'
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Bump version and push tag
         id: bump_version
-        uses: anothrNick/github-tag-action@1.71.0
+        uses: anothrNick/github-tag-action@1.69.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch


### PR DESCRIPTION
Updates the `auto-release.yml` workflow to enhance the conditions under which the release job is triggered. Specifically, it modifies the conditional check from solely relying on `github.event.pull_request.merged == true` to also include `github.event.action == 'merged'`.

**Motivation:**
The change ensures that the release process will be initiated not only when a pull request is merged but also when the action that triggers the merge event occurs. This adjustment is crucial for accommodating various scenarios and improving the reliability of our release workflow.

**Improvements:**
By broadening the trigger conditions, this update helps prevent missed release opportunities, ensuring that our deployment process remains robust and responsive to the necessary events. This will ultimately lead to a more efficient release cycle and better alignment with our development practices.